### PR TITLE
Added method resetRequests to clean the history of requests

### DIFF
--- a/src/main/java/feign/mock/MockClient.java
+++ b/src/main/java/feign/mock/MockClient.java
@@ -127,4 +127,8 @@ public class MockClient implements Client {
             throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!", key);
     }
 
+    public void resetRequests() {
+        requests.clear();
+    }
+
 }

--- a/src/test/java/feign/mock/MockClientTest.java
+++ b/src/test/java/feign/mock/MockClientTest.java
@@ -219,4 +219,18 @@ public class MockClientTest {
         assertThat(results, hasSize(3));
     }
 
+    @Test
+    public void resetRequests() {
+        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
+
+        github.create("netflix", "feign", "velo_at_github", "preposterous hacker");
+        Request result = mockClient.verifyOne(HttpMethod.POST, "/repos/netflix/feign/contributors");
+        assertThat(result, notNullValue());
+
+        mockClient.resetRequests();
+
+        mockClient.verifyNever(HttpMethod.POST, "/repos/netflix/feign/contributors");
+
+    }
+
 }


### PR DESCRIPTION
This solves the problem when you want to check the same invocation in different tests and you want to verify content of the request from verifyOne with that single call.