### PR TITLE
support sequential executions

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -7,17 +7,17 @@ image:https://img.shields.io/github/issues/velo/feign-mock.svg["Issues", link="h
 image:https://img.shields.io/github/forks/velo/feign-mock.svg["Forks", link="https://github.com/velo/feign-mock/network"]
 image:https://img.shields.io/github/stars/velo/feign-mock.svg["Stars", link="https://github.com/velo/feign-mock/stargazers"]
 
-An easy way to test https://github.com/Netflix/feign.  Since using feign most of the logic is store into annotations this helps to check if the annotations are right.
+An easy way to test https://github.com/Netflix/feign. Since feign stores most of the logic in annotations, this helps to check if the annotations are correct.
 
-Original article available https://velo.github.io/2016/06/05/Testing-feign-clients.html[here]
+The original article is available https://velo.github.io/2016/06/05/Testing-feign-clients.html[here]
 
-If mocking feign clients is easy, testing the logic written in annotations is everything but!
+If mocking feign clients is easy, testing the logic written in annotations is not!
 
-To check if you are parsing the request/response properly the only way it firing a real request.  Well, that doesn't seem to be a good path to unit (or even integration) test remote services.  Any IO change will affect test stability.
+To check if you are parsing the request/response properly, the only way is firing a real request. Well, that doesn't seem to be a good path to unit (or even integration) test remote services. Any IO change will affect test stability.
 
-That is why I create https://github.com/velo/feign-mock[feign-mock].
+That is why I created https://github.com/velo/feign-mock[feign-mock].
 
-With feign-mock you can using pre-loaded json strings or streams as content for your responses.  It also allow you to verify mock invokation and feign-mock will hit your annotations to make sure everything works.
+With feign-mock you can use pre-loaded JSON strings or streams as content for your responses. It also allows you to verify mocked invocations and feign-mock will hit your annotations to make sure everything works.
 
 ##### Example
 
@@ -36,6 +36,11 @@ With feign-mock you can using pre-loaded json strings or streams as content for 
         .target(new MockTarget<>(GitHub.class));
   }
 
+  @After
+  public void tearDown() {
+    mockClient.verifyStatus();
+  }
+
   @Test
   public void missHttpMethod() {
     List<Contributor> result = github.patchContributors("velo", "feign-mock");
@@ -44,8 +49,8 @@ With feign-mock you can using pre-loaded json strings or streams as content for 
   }
 ```
 
-This simple test returns no content and verify if the url was trully invoked.
+This simple test returns no content and verifies that the URL was truly invoked.
 
-On mock client, you can include all urls and methods you wanna mock.
+On the mocked client, you can include all URLs and methods you want to mock.
 
-For a more compreensive example take a look at https://github.com/velo/feign-mock/blob/master/src/test/java/feign/mock/MockClientTest.java[MockClientTest].
+For more comprehensive examples take a look at https://github.com/velo/feign-mock/blob/master/src/test/java/feign/mock/MockClientTest.java[MockClientTest].

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -54,3 +54,4 @@ This simple test returns no content and verifies that the URL was truly invoked.
 On the mocked client, you can include all URLs and methods you want to mock.
 
 For more comprehensive examples take a look at https://github.com/velo/feign-mock/blob/master/src/test/java/feign/mock/MockClientTest.java[MockClientTest].
+

--- a/src/main/java/feign/mock/MockClient.java
+++ b/src/main/java/feign/mock/MockClient.java
@@ -15,120 +15,266 @@
  */
 package feign.mock;
 
-import static feign.Util.UTF_8;
-import static feign.Util.toByteArray;
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLDecoder;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 import feign.Client;
 import feign.Request;
-import feign.Request.Options;
 import feign.Response;
+import feign.Util;
 
 public class MockClient implements Client {
 
-    private static final Map<String, Collection<String>> NO_HEADERS = new HashMap<String, Collection<String>>();
+  class RequestResponse {
 
-    private static final int HTTP_NO_CONTENT = 204;
-    private static final int HTTP_OK = 200;
-    private static final int HTTP_NOT_FOUND = 404;
+    private RequestKey requestKey;
 
-    private final Map<RequestKey, Response.Builder> responses = new HashMap<>();
-    private final Map<RequestKey, List<Request>> requests = new HashMap<>();
+    private Response.Builder responseBuilder;
 
-    @Override
-    public Response execute(Request request, Options options) throws IOException {
-        RequestKey key = new RequestKey(HttpMethod.valueOf(request.method()),
-                URLDecoder.decode(request.url(), UTF_8.name()));
-
-        if (requests.containsKey(key))
-            requests.get(key).add(request);
-        else
-            requests.put(key, new ArrayList<>(asList(request)));
-
-        if (responses.containsKey(key))
-            return responses.get(key)
-                    .request(request)
-                    .build();
-
-        return Response.builder()
-                .status(HTTP_NOT_FOUND)
-                .reason("Not mocker")
-                .headers(request.headers())
-                .request(request)
-                .build();
+    public RequestResponse(RequestKey requestKey, Response.Builder responseBuilder) {
+      this.requestKey = requestKey;
+      this.responseBuilder = responseBuilder;
     }
 
-    public MockClient ok(HttpMethod method, String url, InputStream input) throws IOException {
-        return ok(method, url, toByteArray(input));
+  }
+
+  public static final Map<String, Collection<String>> EMPTY_HEADERS = Collections.emptyMap();
+
+  private final List<RequestResponse> responses = new ArrayList<>();
+
+  private final Map<RequestKey, List<Request>> requests = new HashMap<>();
+
+  private boolean sequential;
+
+  private Iterator<RequestResponse> responseIterator;
+
+  public MockClient() {
+  }
+
+  public MockClient(boolean sequential) {
+    this.sequential = sequential;
+  }
+
+  @Override
+  public synchronized Response execute(Request request, Request.Options options) throws IOException {
+    RequestKey requestKey = RequestKey.create(request);
+    Response.Builder responseBuilder;
+    if (sequential) {
+      responseBuilder = executeSequential(requestKey);
+    } else {
+      responseBuilder = executeAny(request, requestKey);
     }
 
-    public MockClient ok(HttpMethod method, String url, String text) {
-        return ok(method, url, text.getBytes());
+    return responseBuilder
+        .request(request)
+        .build();
+  }
+
+  private Response.Builder executeSequential(RequestKey requestKey) {
+    Response.Builder responseBuilder;
+    if (responseIterator == null) {
+      responseIterator = responses.iterator();
+    }
+    if (!responseIterator.hasNext()) {
+      throw new VerificationAssertionError("Received excessive request %s", requestKey);
     }
 
-    public MockClient noContent(HttpMethod method, String url) {
-        return add(method, url, Response.builder()
-                .status(HTTP_NO_CONTENT)
-                .reason("Mocked")
-                .headers(NO_HEADERS));
+    RequestResponse expectedRequestResponse = responseIterator.next();
+    if (!expectedRequestResponse.requestKey.equalsExtended(requestKey)) {
+      throw new VerificationAssertionError("Expected %s, but was %s", expectedRequestResponse.requestKey, requestKey);
     }
 
-    public MockClient ok(HttpMethod method, String url, byte[] data) {
-        return add(method, url, Response.builder()
-                .status(HTTP_OK)
-                .reason("Mocked")
-                .headers(NO_HEADERS)
-                .body(data));
+    responseBuilder = expectedRequestResponse.responseBuilder;
+    return responseBuilder;
+  }
+
+  private Response.Builder executeAny(Request request, RequestKey requestKey) {
+    Response.Builder responseBuilder;
+    if (requests.containsKey(requestKey)) {
+      requests.get(requestKey).add(request);
+    } else {
+      requests.put(requestKey, new ArrayList<>(Arrays.asList(request)));
     }
 
-    public MockClient add(HttpMethod method, String url, Response.Builder response) {
-        responses.put(new RequestKey(method, url), response);
-        return this;
+    responseBuilder = getResponseBuilder(request, requestKey);
+    return responseBuilder;
+  }
+
+  private Response.Builder getResponseBuilder(Request request, RequestKey requestKey) {
+    Response.Builder responseBuilder = null;
+    for (RequestResponse requestResponse : responses) {
+      if (requestResponse.requestKey.equalsExtended(requestKey)) {
+        responseBuilder = requestResponse.responseBuilder;
+        // Don't break here, last one should win to be compatible with previous
+        // releases of this library!
+      }
+    }
+    if (responseBuilder == null) {
+      responseBuilder = Response.builder()
+          .status(HttpURLConnection.HTTP_NOT_FOUND)
+          .reason("Not mocker")
+          .headers(request.headers());
+    }
+    return responseBuilder;
+  }
+
+  /**
+   * @param response
+   * <ul>
+   *   <li>the status defaults to 0, not 200!</li>
+   *   <li>the internal feign-code requires the headers to be set</li>
+   * </ul>
+   */
+  public MockClient add(HttpMethod method, String url, Response.Builder response) {
+    return add(RequestKey.builder(method, url).build(), response);
+  }
+
+  public MockClient add(RequestKey requestKey, Response.Builder response) {
+    responses.add(new RequestResponse(requestKey, response));
+    return this;
+  }
+
+  private MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
+    return add(requestKey, Response.builder()
+        .status(status)
+        .reason("Mocked")
+        .headers(EMPTY_HEADERS)
+        .body(responseBody));
+  }
+
+  public MockClient ok(HttpMethod method, String url, InputStream responseBody) throws IOException {
+    return ok(RequestKey.builder(method, url).build(), responseBody);
+  }
+
+  public MockClient ok(HttpMethod method, String url, String responseBody) {
+    return ok(RequestKey.builder(method, url).build(), responseBody);
+  }
+
+  public MockClient ok(HttpMethod method, String url, byte[] responseBody) {
+    return ok(RequestKey.builder(method, url).build(), responseBody);
+  }
+
+  public MockClient ok(HttpMethod method, String url) {
+    return ok(RequestKey.builder(method, url).build());
+  }
+
+  public MockClient ok(RequestKey requestKey, InputStream responseBody) throws IOException {
+    return ok(requestKey, Util.toByteArray(responseBody));
+  }
+
+  public MockClient ok(RequestKey requestKey, String responseBody) {
+    return ok(requestKey, responseBody.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public MockClient ok(RequestKey requestKey, byte[] responseBody) {
+    return add(requestKey, HttpURLConnection.HTTP_OK, responseBody);
+  }
+
+  public MockClient ok(RequestKey requestKey) {
+    return ok(requestKey, (byte[]) null);
+  }
+
+  public MockClient notOk(HttpMethod method, String url, int status, InputStream responseBody) throws IOException {
+    return notOk(RequestKey.builder(method, url).build(), status, responseBody);
+  }
+
+  public MockClient notOk(HttpMethod method, String url, int status, String responseBody) {
+    return notOk(RequestKey.builder(method, url).build(), status, responseBody);
+  }
+
+  public MockClient notOk(HttpMethod method, String url, int status, byte[] responseBody) {
+    return notOk(RequestKey.builder(method, url).build(), status, responseBody);
+  }
+
+  public MockClient notOk(HttpMethod method, String url, int status) {
+    return notOk(RequestKey.builder(method, url).build(), status);
+  }
+
+  public MockClient notOk(RequestKey requestKey, int status, InputStream responseBody) throws IOException {
+    return notOk(requestKey, status, Util.toByteArray(responseBody));
+  }
+
+  public MockClient notOk(RequestKey requestKey, int status, String responseBody) {
+    return notOk(requestKey, status, responseBody.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public MockClient notOk(RequestKey requestKey, int status, byte[] responseBody) {
+    return add(requestKey, status, responseBody);
+  }
+
+  public MockClient notOk(RequestKey requestKey, int status) {
+    return notOk(requestKey, status, (byte[]) null);
+  }
+
+  public MockClient noContent(HttpMethod method, String url) {
+    return notOk(method, url, HttpURLConnection.HTTP_NO_CONTENT);
+  }
+
+  public Request verifyOne(HttpMethod method, String url) {
+    return verifyTimes(method, url, 1).get(0);
+  }
+
+  public List<Request> verifyTimes(final HttpMethod method, final String url, final int times) {
+    if (times < 0) {
+      throw new IllegalArgumentException("times must be a non negative number");
     }
 
-    public Request verifyOne(HttpMethod method, String url) {
-        return verifyTimes(method, url, 1).get(0);
+    if (times == 0) {
+      verifyNever(method, url);
+      return Collections.emptyList();
     }
 
-    public List<Request> verifyTimes(final HttpMethod method, final String url, final int times) {
-        if (times < 0)
-            throw new IllegalArgumentException("times must be a non negative number");
-
-        if (times == 0) {
-            verifyNever(method, url);
-            return emptyList();
-        }
-
-        RequestKey key = new RequestKey(method, url);
-        if (!requests.containsKey(key))
-            throw new VerificationAssertionError("Wanted: '%s' but never invoked!", key);
-
-        List<Request> result = requests.get(key);
-        if (result.size() == times)
-            return result;
-
-        throw new VerificationAssertionError("Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
-                key, times, result.size());
+    RequestKey requestKey = RequestKey.builder(method, url).build();
+    if (!requests.containsKey(requestKey)) {
+      throw new VerificationAssertionError("Wanted: '%s' but never invoked!", requestKey);
     }
 
-    public void verifyNever(HttpMethod method, String url) {
-        RequestKey key = new RequestKey(method, url);
-        if (requests.containsKey(key))
-            throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!", key);
+    List<Request> result = requests.get(requestKey);
+    if (result.size() != times) {
+      throw new VerificationAssertionError("Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
+          requestKey, times, result.size());
     }
 
-    public void resetRequests() {
-        requests.clear();
+    return result;
+  }
+
+  public void verifyNever(HttpMethod method, String url) {
+    RequestKey requestKey = RequestKey.builder(method, url).build();
+    if (requests.containsKey(requestKey)) {
+      throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!", requestKey);
     }
+  }
+
+  /**
+   * To be called in an &#64;After method:
+   * <pre>
+   *   &#64;After
+   *   public void tearDown() {
+   *     mockClient.verifyStatus();
+   *   }
+   * </pre>
+   */
+  public void verifyStatus() {
+    if (sequential) {
+      boolean unopenedIterator = responseIterator == null && !responses.isEmpty();
+      if (unopenedIterator || responseIterator.hasNext()) {
+        throw new VerificationAssertionError("More executions were expected");
+      }
+    }
+  }
+
+  public void resetRequests() {
+    requests.clear();
+  }
 
 }

--- a/src/main/java/feign/mock/MockClient.java
+++ b/src/main/java/feign/mock/MockClient.java
@@ -37,9 +37,9 @@ public class MockClient implements Client {
 
     class RequestResponse {
 
-        private RequestKey requestKey;
+        private final RequestKey requestKey;
 
-        private Response.Builder responseBuilder;
+        private final Response.Builder responseBuilder;
 
         public RequestResponse(RequestKey requestKey, Response.Builder responseBuilder) {
             this.requestKey = requestKey;
@@ -128,30 +128,6 @@ public class MockClient implements Client {
         return responseBuilder;
     }
 
-    /**
-     * @param response
-     * <ul>
-     *   <li>the status defaults to 0, not 200!</li>
-     *   <li>the internal feign-code requires the headers to be set</li>
-     * </ul>
-     */
-    public MockClient add(HttpMethod method, String url, Response.Builder response) {
-        return add(RequestKey.builder(method, url).build(), response);
-    }
-
-    public MockClient add(RequestKey requestKey, Response.Builder response) {
-        responses.add(new RequestResponse(requestKey, response));
-        return this;
-    }
-
-    private MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
-        return add(requestKey, Response.builder()
-                .status(status)
-                .reason("Mocked")
-                .headers(EMPTY_HEADERS)
-                .body(responseBody));
-    }
-
     public MockClient ok(HttpMethod method, String url, InputStream responseBody) throws IOException {
         return ok(RequestKey.builder(method, url).build(), responseBody);
     }
@@ -184,40 +160,60 @@ public class MockClient implements Client {
         return ok(requestKey, (byte[]) null);
     }
 
-    public MockClient notOk(HttpMethod method, String url, int status, InputStream responseBody) throws IOException {
-        return notOk(RequestKey.builder(method, url).build(), status, responseBody);
+    public MockClient add(HttpMethod method, String url, int status, InputStream responseBody) throws IOException {
+        return add(RequestKey.builder(method, url).build(), status, responseBody);
     }
 
-    public MockClient notOk(HttpMethod method, String url, int status, String responseBody) {
-        return notOk(RequestKey.builder(method, url).build(), status, responseBody);
+    public MockClient add(HttpMethod method, String url, int status, String responseBody) {
+        return add(RequestKey.builder(method, url).build(), status, responseBody);
     }
 
-    public MockClient notOk(HttpMethod method, String url, int status, byte[] responseBody) {
-        return notOk(RequestKey.builder(method, url).build(), status, responseBody);
+    public MockClient add(HttpMethod method, String url, int status, byte[] responseBody) {
+        return add(RequestKey.builder(method, url).build(), status, responseBody);
     }
 
-    public MockClient notOk(HttpMethod method, String url, int status) {
-        return notOk(RequestKey.builder(method, url).build(), status);
+    public MockClient add(HttpMethod method, String url, int status) {
+        return add(RequestKey.builder(method, url).build(), status);
     }
 
-    public MockClient notOk(RequestKey requestKey, int status, InputStream responseBody) throws IOException {
-        return notOk(requestKey, status, Util.toByteArray(responseBody));
+    /**
+     * @param response
+     * <ul>
+     *   <li>the status defaults to 0, not 200!</li>
+     *   <li>the internal feign-code requires the headers to be set</li>
+     * </ul>
+     */
+    public MockClient add(HttpMethod method, String url, Response.Builder response) {
+        return add(RequestKey.builder(method, url).build(), response);
     }
 
-    public MockClient notOk(RequestKey requestKey, int status, String responseBody) {
-        return notOk(requestKey, status, responseBody.getBytes(StandardCharsets.UTF_8));
+    public MockClient add(RequestKey requestKey, int status, InputStream responseBody) throws IOException {
+        return add(requestKey, status, Util.toByteArray(responseBody));
     }
 
-    public MockClient notOk(RequestKey requestKey, int status, byte[] responseBody) {
-        return add(requestKey, status, responseBody);
+    public MockClient add(RequestKey requestKey, int status, String responseBody) {
+        return add(requestKey, status, responseBody.getBytes(StandardCharsets.UTF_8));
     }
 
-    public MockClient notOk(RequestKey requestKey, int status) {
-        return notOk(requestKey, status, (byte[]) null);
+    public MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
+        return add(requestKey, Response.builder()
+                .status(status)
+                .reason("Mocked")
+                .headers(EMPTY_HEADERS)
+                .body(responseBody));
+    }
+
+    public MockClient add(RequestKey requestKey, int status) {
+        return add(requestKey, status, (byte[]) null);
+    }
+
+    public MockClient add(RequestKey requestKey, Response.Builder response) {
+        responses.add(new RequestResponse(requestKey, response));
+        return this;
     }
 
     public MockClient noContent(HttpMethod method, String url) {
-        return notOk(method, url, HttpURLConnection.HTTP_NO_CONTENT);
+        return add(method, url, HttpURLConnection.HTTP_NO_CONTENT);
     }
 
     public Request verifyOne(HttpMethod method, String url) {

--- a/src/main/java/feign/mock/MockClient.java
+++ b/src/main/java/feign/mock/MockClient.java
@@ -35,246 +35,246 @@ import feign.Util;
 
 public class MockClient implements Client {
 
-  class RequestResponse {
+    class RequestResponse {
 
-    private RequestKey requestKey;
+        private RequestKey requestKey;
 
-    private Response.Builder responseBuilder;
+        private Response.Builder responseBuilder;
 
-    public RequestResponse(RequestKey requestKey, Response.Builder responseBuilder) {
-      this.requestKey = requestKey;
-      this.responseBuilder = responseBuilder;
+        public RequestResponse(RequestKey requestKey, Response.Builder responseBuilder) {
+            this.requestKey = requestKey;
+            this.responseBuilder = responseBuilder;
+        }
+
     }
 
-  }
+    public static final Map<String, Collection<String>> EMPTY_HEADERS = Collections.emptyMap();
 
-  public static final Map<String, Collection<String>> EMPTY_HEADERS = Collections.emptyMap();
+    private final List<RequestResponse> responses = new ArrayList<>();
 
-  private final List<RequestResponse> responses = new ArrayList<>();
+    private final Map<RequestKey, List<Request>> requests = new HashMap<>();
 
-  private final Map<RequestKey, List<Request>> requests = new HashMap<>();
+    private boolean sequential;
 
-  private boolean sequential;
+    private Iterator<RequestResponse> responseIterator;
 
-  private Iterator<RequestResponse> responseIterator;
-
-  public MockClient() {
-  }
-
-  public MockClient(boolean sequential) {
-    this.sequential = sequential;
-  }
-
-  @Override
-  public synchronized Response execute(Request request, Request.Options options) throws IOException {
-    RequestKey requestKey = RequestKey.create(request);
-    Response.Builder responseBuilder;
-    if (sequential) {
-      responseBuilder = executeSequential(requestKey);
-    } else {
-      responseBuilder = executeAny(request, requestKey);
+    public MockClient() {
     }
 
-    return responseBuilder
-        .request(request)
-        .build();
-  }
-
-  private Response.Builder executeSequential(RequestKey requestKey) {
-    Response.Builder responseBuilder;
-    if (responseIterator == null) {
-      responseIterator = responses.iterator();
-    }
-    if (!responseIterator.hasNext()) {
-      throw new VerificationAssertionError("Received excessive request %s", requestKey);
+    public MockClient(boolean sequential) {
+        this.sequential = sequential;
     }
 
-    RequestResponse expectedRequestResponse = responseIterator.next();
-    if (!expectedRequestResponse.requestKey.equalsExtended(requestKey)) {
-      throw new VerificationAssertionError("Expected %s, but was %s", expectedRequestResponse.requestKey, requestKey);
+    @Override
+    public synchronized Response execute(Request request, Request.Options options) throws IOException {
+        RequestKey requestKey = RequestKey.create(request);
+        Response.Builder responseBuilder;
+        if (sequential) {
+            responseBuilder = executeSequential(requestKey);
+        } else {
+            responseBuilder = executeAny(request, requestKey);
+        }
+
+        return responseBuilder
+                .request(request)
+                .build();
     }
 
-    responseBuilder = expectedRequestResponse.responseBuilder;
-    return responseBuilder;
-  }
+    private Response.Builder executeSequential(RequestKey requestKey) {
+        Response.Builder responseBuilder;
+        if (responseIterator == null) {
+            responseIterator = responses.iterator();
+        }
+        if (!responseIterator.hasNext()) {
+            throw new VerificationAssertionError("Received excessive request %s", requestKey);
+        }
 
-  private Response.Builder executeAny(Request request, RequestKey requestKey) {
-    Response.Builder responseBuilder;
-    if (requests.containsKey(requestKey)) {
-      requests.get(requestKey).add(request);
-    } else {
-      requests.put(requestKey, new ArrayList<>(Arrays.asList(request)));
+        RequestResponse expectedRequestResponse = responseIterator.next();
+        if (!expectedRequestResponse.requestKey.equalsExtended(requestKey)) {
+            throw new VerificationAssertionError("Expected %s, but was %s", expectedRequestResponse.requestKey, requestKey);
+        }
+
+        responseBuilder = expectedRequestResponse.responseBuilder;
+        return responseBuilder;
     }
 
-    responseBuilder = getResponseBuilder(request, requestKey);
-    return responseBuilder;
-  }
+    private Response.Builder executeAny(Request request, RequestKey requestKey) {
+        Response.Builder responseBuilder;
+        if (requests.containsKey(requestKey)) {
+            requests.get(requestKey).add(request);
+        } else {
+            requests.put(requestKey, new ArrayList<>(Arrays.asList(request)));
+        }
 
-  private Response.Builder getResponseBuilder(Request request, RequestKey requestKey) {
-    Response.Builder responseBuilder = null;
-    for (RequestResponse requestResponse : responses) {
-      if (requestResponse.requestKey.equalsExtended(requestKey)) {
-        responseBuilder = requestResponse.responseBuilder;
-        // Don't break here, last one should win to be compatible with previous
-        // releases of this library!
-      }
-    }
-    if (responseBuilder == null) {
-      responseBuilder = Response.builder()
-          .status(HttpURLConnection.HTTP_NOT_FOUND)
-          .reason("Not mocker")
-          .headers(request.headers());
-    }
-    return responseBuilder;
-  }
-
-  /**
-   * @param response
-   * <ul>
-   *   <li>the status defaults to 0, not 200!</li>
-   *   <li>the internal feign-code requires the headers to be set</li>
-   * </ul>
-   */
-  public MockClient add(HttpMethod method, String url, Response.Builder response) {
-    return add(RequestKey.builder(method, url).build(), response);
-  }
-
-  public MockClient add(RequestKey requestKey, Response.Builder response) {
-    responses.add(new RequestResponse(requestKey, response));
-    return this;
-  }
-
-  private MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
-    return add(requestKey, Response.builder()
-        .status(status)
-        .reason("Mocked")
-        .headers(EMPTY_HEADERS)
-        .body(responseBody));
-  }
-
-  public MockClient ok(HttpMethod method, String url, InputStream responseBody) throws IOException {
-    return ok(RequestKey.builder(method, url).build(), responseBody);
-  }
-
-  public MockClient ok(HttpMethod method, String url, String responseBody) {
-    return ok(RequestKey.builder(method, url).build(), responseBody);
-  }
-
-  public MockClient ok(HttpMethod method, String url, byte[] responseBody) {
-    return ok(RequestKey.builder(method, url).build(), responseBody);
-  }
-
-  public MockClient ok(HttpMethod method, String url) {
-    return ok(RequestKey.builder(method, url).build());
-  }
-
-  public MockClient ok(RequestKey requestKey, InputStream responseBody) throws IOException {
-    return ok(requestKey, Util.toByteArray(responseBody));
-  }
-
-  public MockClient ok(RequestKey requestKey, String responseBody) {
-    return ok(requestKey, responseBody.getBytes(StandardCharsets.UTF_8));
-  }
-
-  public MockClient ok(RequestKey requestKey, byte[] responseBody) {
-    return add(requestKey, HttpURLConnection.HTTP_OK, responseBody);
-  }
-
-  public MockClient ok(RequestKey requestKey) {
-    return ok(requestKey, (byte[]) null);
-  }
-
-  public MockClient notOk(HttpMethod method, String url, int status, InputStream responseBody) throws IOException {
-    return notOk(RequestKey.builder(method, url).build(), status, responseBody);
-  }
-
-  public MockClient notOk(HttpMethod method, String url, int status, String responseBody) {
-    return notOk(RequestKey.builder(method, url).build(), status, responseBody);
-  }
-
-  public MockClient notOk(HttpMethod method, String url, int status, byte[] responseBody) {
-    return notOk(RequestKey.builder(method, url).build(), status, responseBody);
-  }
-
-  public MockClient notOk(HttpMethod method, String url, int status) {
-    return notOk(RequestKey.builder(method, url).build(), status);
-  }
-
-  public MockClient notOk(RequestKey requestKey, int status, InputStream responseBody) throws IOException {
-    return notOk(requestKey, status, Util.toByteArray(responseBody));
-  }
-
-  public MockClient notOk(RequestKey requestKey, int status, String responseBody) {
-    return notOk(requestKey, status, responseBody.getBytes(StandardCharsets.UTF_8));
-  }
-
-  public MockClient notOk(RequestKey requestKey, int status, byte[] responseBody) {
-    return add(requestKey, status, responseBody);
-  }
-
-  public MockClient notOk(RequestKey requestKey, int status) {
-    return notOk(requestKey, status, (byte[]) null);
-  }
-
-  public MockClient noContent(HttpMethod method, String url) {
-    return notOk(method, url, HttpURLConnection.HTTP_NO_CONTENT);
-  }
-
-  public Request verifyOne(HttpMethod method, String url) {
-    return verifyTimes(method, url, 1).get(0);
-  }
-
-  public List<Request> verifyTimes(final HttpMethod method, final String url, final int times) {
-    if (times < 0) {
-      throw new IllegalArgumentException("times must be a non negative number");
+        responseBuilder = getResponseBuilder(request, requestKey);
+        return responseBuilder;
     }
 
-    if (times == 0) {
-      verifyNever(method, url);
-      return Collections.emptyList();
+    private Response.Builder getResponseBuilder(Request request, RequestKey requestKey) {
+        Response.Builder responseBuilder = null;
+        for (RequestResponse requestResponse : responses) {
+            if (requestResponse.requestKey.equalsExtended(requestKey)) {
+                responseBuilder = requestResponse.responseBuilder;
+                // Don't break here, last one should win to be compatible with previous
+                // releases of this library!
+            }
+        }
+        if (responseBuilder == null) {
+            responseBuilder = Response.builder()
+                    .status(HttpURLConnection.HTTP_NOT_FOUND)
+                    .reason("Not mocker")
+                    .headers(request.headers());
+        }
+        return responseBuilder;
     }
 
-    RequestKey requestKey = RequestKey.builder(method, url).build();
-    if (!requests.containsKey(requestKey)) {
-      throw new VerificationAssertionError("Wanted: '%s' but never invoked!", requestKey);
+    /**
+     * @param response
+     * <ul>
+     *   <li>the status defaults to 0, not 200!</li>
+     *   <li>the internal feign-code requires the headers to be set</li>
+     * </ul>
+     */
+    public MockClient add(HttpMethod method, String url, Response.Builder response) {
+        return add(RequestKey.builder(method, url).build(), response);
     }
 
-    List<Request> result = requests.get(requestKey);
-    if (result.size() != times) {
-      throw new VerificationAssertionError("Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
-          requestKey, times, result.size());
+    public MockClient add(RequestKey requestKey, Response.Builder response) {
+        responses.add(new RequestResponse(requestKey, response));
+        return this;
     }
 
-    return result;
-  }
-
-  public void verifyNever(HttpMethod method, String url) {
-    RequestKey requestKey = RequestKey.builder(method, url).build();
-    if (requests.containsKey(requestKey)) {
-      throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!", requestKey);
+    private MockClient add(RequestKey requestKey, int status, byte[] responseBody) {
+        return add(requestKey, Response.builder()
+                .status(status)
+                .reason("Mocked")
+                .headers(EMPTY_HEADERS)
+                .body(responseBody));
     }
-  }
 
-  /**
-   * To be called in an &#64;After method:
-   * <pre>
-   *   &#64;After
-   *   public void tearDown() {
-   *     mockClient.verifyStatus();
-   *   }
-   * </pre>
-   */
-  public void verifyStatus() {
-    if (sequential) {
-      boolean unopenedIterator = responseIterator == null && !responses.isEmpty();
-      if (unopenedIterator || responseIterator.hasNext()) {
-        throw new VerificationAssertionError("More executions were expected");
-      }
+    public MockClient ok(HttpMethod method, String url, InputStream responseBody) throws IOException {
+        return ok(RequestKey.builder(method, url).build(), responseBody);
     }
-  }
 
-  public void resetRequests() {
-    requests.clear();
-  }
+    public MockClient ok(HttpMethod method, String url, String responseBody) {
+        return ok(RequestKey.builder(method, url).build(), responseBody);
+    }
+
+    public MockClient ok(HttpMethod method, String url, byte[] responseBody) {
+        return ok(RequestKey.builder(method, url).build(), responseBody);
+    }
+
+    public MockClient ok(HttpMethod method, String url) {
+        return ok(RequestKey.builder(method, url).build());
+    }
+
+    public MockClient ok(RequestKey requestKey, InputStream responseBody) throws IOException {
+        return ok(requestKey, Util.toByteArray(responseBody));
+    }
+
+    public MockClient ok(RequestKey requestKey, String responseBody) {
+        return ok(requestKey, responseBody.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public MockClient ok(RequestKey requestKey, byte[] responseBody) {
+        return add(requestKey, HttpURLConnection.HTTP_OK, responseBody);
+    }
+
+    public MockClient ok(RequestKey requestKey) {
+        return ok(requestKey, (byte[]) null);
+    }
+
+    public MockClient notOk(HttpMethod method, String url, int status, InputStream responseBody) throws IOException {
+        return notOk(RequestKey.builder(method, url).build(), status, responseBody);
+    }
+
+    public MockClient notOk(HttpMethod method, String url, int status, String responseBody) {
+        return notOk(RequestKey.builder(method, url).build(), status, responseBody);
+    }
+
+    public MockClient notOk(HttpMethod method, String url, int status, byte[] responseBody) {
+        return notOk(RequestKey.builder(method, url).build(), status, responseBody);
+    }
+
+    public MockClient notOk(HttpMethod method, String url, int status) {
+        return notOk(RequestKey.builder(method, url).build(), status);
+    }
+
+    public MockClient notOk(RequestKey requestKey, int status, InputStream responseBody) throws IOException {
+        return notOk(requestKey, status, Util.toByteArray(responseBody));
+    }
+
+    public MockClient notOk(RequestKey requestKey, int status, String responseBody) {
+        return notOk(requestKey, status, responseBody.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public MockClient notOk(RequestKey requestKey, int status, byte[] responseBody) {
+        return add(requestKey, status, responseBody);
+    }
+
+    public MockClient notOk(RequestKey requestKey, int status) {
+        return notOk(requestKey, status, (byte[]) null);
+    }
+
+    public MockClient noContent(HttpMethod method, String url) {
+        return notOk(method, url, HttpURLConnection.HTTP_NO_CONTENT);
+    }
+
+    public Request verifyOne(HttpMethod method, String url) {
+        return verifyTimes(method, url, 1).get(0);
+    }
+
+    public List<Request> verifyTimes(final HttpMethod method, final String url, final int times) {
+        if (times < 0) {
+            throw new IllegalArgumentException("times must be a non negative number");
+        }
+
+        if (times == 0) {
+            verifyNever(method, url);
+            return Collections.emptyList();
+        }
+
+        RequestKey requestKey = RequestKey.builder(method, url).build();
+        if (!requests.containsKey(requestKey)) {
+            throw new VerificationAssertionError("Wanted: '%s' but never invoked!", requestKey);
+        }
+
+        List<Request> result = requests.get(requestKey);
+        if (result.size() != times) {
+            throw new VerificationAssertionError("Wanted: '%s' to be invoked: '%s' times but got: '%s'!",
+                    requestKey, times, result.size());
+        }
+
+        return result;
+    }
+
+    public void verifyNever(HttpMethod method, String url) {
+        RequestKey requestKey = RequestKey.builder(method, url).build();
+        if (requests.containsKey(requestKey)) {
+            throw new VerificationAssertionError("Do not wanted: '%s' but was invoked!", requestKey);
+        }
+    }
+
+    /**
+     * To be called in an &#64;After method:
+     * <pre>
+     *   &#64;After
+     *   public void tearDown() {
+     *     mockClient.verifyStatus();
+     *   }
+     * </pre>
+     */
+    public void verifyStatus() {
+        if (sequential) {
+            boolean unopenedIterator = responseIterator == null && !responses.isEmpty();
+            if (unopenedIterator || responseIterator.hasNext()) {
+                throw new VerificationAssertionError("More executions were expected");
+            }
+        }
+    }
+
+    public void resetRequests() {
+        requests.clear();
+    }
 
 }

--- a/src/main/java/feign/mock/RequestKey.java
+++ b/src/main/java/feign/mock/RequestKey.java
@@ -31,9 +31,9 @@ public class RequestKey {
 
     public static class Builder {
 
-        private HttpMethod method;
+        private final HttpMethod method;
 
-        private String url;
+        private final String url;
 
         private Map<String, Collection<String>> headers;
 
@@ -66,13 +66,7 @@ public class RequestKey {
         }
 
         public RequestKey build() {
-            RequestKey requestKey = new RequestKey();
-            requestKey.method = method;
-            requestKey.url = url;
-            requestKey.headers = headers;
-            requestKey.charset = charset;
-            requestKey.body = body;
-            return requestKey;
+            return new RequestKey(this);
         }
 
     }
@@ -82,13 +76,7 @@ public class RequestKey {
     }
 
     public static RequestKey create(Request request) {
-        RequestKey requestKey = new RequestKey();
-        requestKey.method = HttpMethod.valueOf(request.method());
-        requestKey.url = buildUrl(request);
-        requestKey.headers = request.headers();
-        requestKey.charset = request.charset();
-        requestKey.body = request.body();
-        return requestKey;
+        return new RequestKey(request);
     }
 
     private static String buildUrl(Request request) {
@@ -99,17 +87,30 @@ public class RequestKey {
         }
     }
 
-    private HttpMethod method;
+    private final HttpMethod method;
 
-    private String url;
+    private final String url;
 
-    private Map<String, Collection<String>> headers;
+    private final Map<String, Collection<String>> headers;
 
-    private Charset charset;
+    private final Charset charset;
 
-    private byte[] body;
+    private final byte[] body;
 
-    private RequestKey() {
+    private RequestKey(Builder builder) {
+        this.method = builder.method;
+        this.url = builder.url;
+        this.headers = builder.headers;
+        this.charset = builder.charset;
+        this.body = builder.body;
+    }
+
+    private RequestKey(Request request) {
+        this.method = HttpMethod.valueOf(request.method());
+        this.url = buildUrl(request);
+        this.headers = request.headers();
+        this.charset = request.charset();
+        this.body = request.body();
     }
 
     public HttpMethod getMethod() {

--- a/src/main/java/feign/mock/RequestKey.java
+++ b/src/main/java/feign/mock/RequestKey.java
@@ -29,7 +29,75 @@ import feign.Util;
 
 public class RequestKey {
 
-  public static class Builder {
+    public static class Builder {
+
+        private HttpMethod method;
+
+        private String url;
+
+        private Map<String, Collection<String>> headers;
+
+        private Charset charset;
+
+        private byte[] body;
+
+        private Builder(HttpMethod method, String url) {
+            this.method = method;
+            this.url = url;
+        }
+
+        public Builder headers(Map<String, Collection<String>> headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        public Builder charset(Charset charset) {
+            this.charset = charset;
+            return this;
+        }
+
+        public Builder body(String body) {
+            return body(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        public Builder body(byte[] body) {
+            this.body = body;
+            return this;
+        }
+
+        public RequestKey build() {
+            RequestKey requestKey = new RequestKey();
+            requestKey.method = method;
+            requestKey.url = url;
+            requestKey.headers = headers;
+            requestKey.charset = charset;
+            requestKey.body = body;
+            return requestKey;
+        }
+
+    }
+
+    public static Builder builder(HttpMethod method, String url) {
+        return new Builder(method, url);
+    }
+
+    public static RequestKey create(Request request) {
+        RequestKey requestKey = new RequestKey();
+        requestKey.method = HttpMethod.valueOf(request.method());
+        requestKey.url = buildUrl(request);
+        requestKey.headers = request.headers();
+        requestKey.charset = request.charset();
+        requestKey.body = request.body();
+        return requestKey;
+    }
+
+    private static String buildUrl(Request request) {
+        try {
+            return URLDecoder.decode(request.url(), Util.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     private HttpMethod method;
 
@@ -41,132 +109,64 @@ public class RequestKey {
 
     private byte[] body;
 
-    private Builder(HttpMethod method, String url) {
-      this.method = method;
-      this.url = url;
+    private RequestKey() {
     }
 
-    public Builder headers(Map<String, Collection<String>> headers) {
-      this.headers = headers;
-      return this;
+    public HttpMethod getMethod() {
+        return method;
     }
 
-    public Builder charset(Charset charset) {
-      this.charset = charset;
-      return this;
+    public String getUrl() {
+        return url;
     }
 
-    public Builder body(String body) {
-      return body(body.getBytes(StandardCharsets.UTF_8));
+    public Map<String, Collection<String>> getHeaders() {
+        return headers;
     }
 
-    public Builder body(byte[] body) {
-      this.body = body;
-      return this;
+    public Charset getCharset() {
+        return charset;
     }
 
-    public RequestKey build() {
-      RequestKey requestKey = new RequestKey();
-      requestKey.method = method;
-      requestKey.url = url;
-      requestKey.headers = headers;
-      requestKey.charset = charset;
-      requestKey.body = body;
-      return requestKey;
+    public byte[] getBody() {
+        return body;
     }
 
-  }
-
-  public static Builder builder(HttpMethod method, String url) {
-    return new Builder(method, url);
-  }
-
-  public static RequestKey create(Request request) {
-    RequestKey requestKey = new RequestKey();
-    requestKey.method = HttpMethod.valueOf(request.method());
-    requestKey.url = buildUrl(request);
-    requestKey.headers = request.headers();
-    requestKey.charset = request.charset();
-    requestKey.body = request.body();
-    return requestKey;
-  }
-
-  private static String buildUrl(Request request) {
-    try {
-      return URLDecoder.decode(request.url(), Util.UTF_8.name());
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private HttpMethod method;
-
-  private String url;
-
-  private Map<String, Collection<String>> headers;
-
-  private Charset charset;
-
-  private byte[] body;
-
-  private RequestKey() {
-  }
-
-  public HttpMethod getMethod() {
-    return method;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public Map<String, Collection<String>> getHeaders() {
-    return headers;
-  }
-
-  public Charset getCharset() {
-    return charset;
-  }
-
-  public byte[] getBody() {
-    return body;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(method, url);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null || getClass() != obj.getClass()) {
-      return false;
+    @Override
+    public int hashCode() {
+        return Objects.hash(method, url);
     }
 
-    RequestKey other = (RequestKey) obj;
-    return Objects.equals(other.method, method) && Objects.equals(other.url, url);
-  }
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
 
-  public boolean equalsExtended(Object obj) {
-    if (equals(obj)) {
-      RequestKey other = (RequestKey) obj;
-      boolean headersEqual = other.headers == null || headers == null || Objects.equals(other.headers, headers);
-      boolean charsetEqual = other.charset == null || charset == null || Objects.equals(other.charset, charset);
-      boolean bodyEqual = other.body == null || body == null || Arrays.equals(other.body, body);
-      return headersEqual && charsetEqual && bodyEqual;
+        RequestKey other = (RequestKey) obj;
+        return Objects.equals(other.method, method) && Objects.equals(other.url, url);
     }
-    return false;
-  }
 
-  @Override
-  public String toString() {
-    return String.format("Request [%s %s: %s headers and %s]",
-        method, url,
-        headers == null ? "without" : "with " + headers.size(),
-        charset == null ? "no charset" : "charset " + charset);
-  }
+    public boolean equalsExtended(Object obj) {
+        if (equals(obj)) {
+            RequestKey other = (RequestKey) obj;
+            boolean headersEqual = other.headers == null || headers == null || Objects.equals(other.headers, headers);
+            boolean charsetEqual = other.charset == null || charset == null || Objects.equals(other.charset, charset);
+            boolean bodyEqual = other.body == null || body == null || Arrays.equals(other.body, body);
+            return headersEqual && charsetEqual && bodyEqual;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Request [%s %s: %s headers and %s]",
+                method, url,
+                headers == null ? "without" : "with " + headers.size(),
+                charset == null ? "no charset" : "charset " + charset);
+    }
 
 }

--- a/src/test/java/feign/mock/MockClientSequentialTest.java
+++ b/src/test/java/feign/mock/MockClientSequentialTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) 2016 Marvin Herman Froeder (marvin@marvinformatics.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign.mock;
+
+import static feign.Util.toByteArray;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import javax.net.ssl.HttpsURLConnection;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import feign.Body;
+import feign.Feign;
+import feign.FeignException;
+import feign.Param;
+import feign.RequestLine;
+import feign.Response;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import feign.gson.GsonDecoder;
+
+public class MockClientSequentialTest {
+
+    interface GitHub {
+
+        @RequestLine("GET /repos/{owner}/{repo}/contributors")
+        List<Contributor> contributors(@Param("owner") String owner, @Param("repo") String repo);
+
+        @RequestLine("GET /repos/{owner}/{repo}/contributors?client_id={client_id}")
+        List<Contributor> contributors(@Param("client_id") String clientId, @Param("owner") String owner,
+                @Param("repo") String repo);
+
+        @RequestLine("PATCH /repos/{owner}/{repo}/contributors")
+        List<Contributor> patchContributors(@Param("owner") String owner, @Param("repo") String repo);
+
+        @RequestLine("POST /repos/{owner}/{repo}/contributors")
+        @Body("%7B\"login\":\"{login}\",\"type\":\"{type}\"%7D")
+        Contributor create(@Param("owner") String owner, @Param("repo") String repo, @Param("login") String login,
+                @Param("type") String type);
+
+    }
+
+    static class Contributor {
+
+        String login;
+
+        int contributions;
+
+    }
+
+    class AssertionDecoder implements Decoder {
+
+        private final Decoder delegate;
+
+        public AssertionDecoder(Decoder delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object decode(Response response, Type type) throws IOException, DecodeException, FeignException {
+            assertThat(response.request(), notNullValue());
+
+            return delegate.decode(response, type);
+        }
+
+    }
+
+    private GitHub githubSequential;
+
+    private MockClient mockClientSequential;
+
+    @Before
+    public void setup() throws IOException {
+        try (InputStream input = getClass().getResourceAsStream("/fixtures/contributors.json")) {
+            byte[] data = toByteArray(input);
+
+            mockClientSequential = new MockClient(true);
+            githubSequential = Feign.builder()
+                    .decoder(new AssertionDecoder(new GsonDecoder()))
+                    .client(mockClientSequential
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors", HttpsURLConnection.HTTP_OK, data)
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=55", HttpsURLConnection.HTTP_NOT_FOUND)
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors?client_id=7 7", HttpsURLConnection.HTTP_INTERNAL_ERROR, new ByteArrayInputStream(data))
+                            .add(HttpMethod.GET, "/repos/netflix/feign/contributors", Response.builder()
+                                    .status(HttpsURLConnection.HTTP_OK)
+                                    .headers(MockClient.EMPTY_HEADERS)
+                                    .body(data)))
+                    .target(new MockTarget<>(GitHub.class));
+        }
+    }
+
+    @Test
+    public void sequentialRequests() throws Exception {
+        githubSequential.contributors("netflix", "feign");
+        try {
+            githubSequential.contributors("55", "netflix", "feign");
+            fail();
+        } catch (FeignException e) {
+            assertThat(e.status(), equalTo(HttpsURLConnection.HTTP_NOT_FOUND));
+        }
+        try {
+            githubSequential.contributors("7 7", "netflix", "feign");
+            fail();
+        } catch (FeignException e) {
+            assertThat(e.status(), equalTo(HttpsURLConnection.HTTP_INTERNAL_ERROR));
+        }
+        githubSequential.contributors("netflix", "feign");
+
+        mockClientSequential.verifyStatus();
+    }
+
+    @Test
+    public void sequentialRequestsCalledTooLess() throws Exception {
+        githubSequential.contributors("netflix", "feign");
+        try {
+            mockClientSequential.verifyStatus();
+            fail();
+        } catch (VerificationAssertionError e) {
+            assertThat(e.getMessage(), startsWith("More executions"));
+        }
+    }
+
+    @Test
+    public void sequentialRequestsCalledTooMany() throws Exception {
+        sequentialRequests();
+
+        try {
+            githubSequential.contributors("netflix", "feign");
+            fail();
+        } catch (VerificationAssertionError e) {
+            assertThat(e.getMessage(), containsString("excessive"));
+        }
+    }
+
+    @Test
+    public void sequentialRequestsInWrongOrder() throws Exception {
+        try {
+            githubSequential.contributors("7 7", "netflix", "feign");
+            fail();
+        } catch (VerificationAssertionError e) {
+            assertThat(e.getMessage(), startsWith("Expected Request ["));
+        }
+    }
+
+}

--- a/src/test/java/feign/mock/RequestKeyTest.java
+++ b/src/test/java/feign/mock/RequestKeyTest.java
@@ -15,51 +15,153 @@
  */
 package feign.mock;
 
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
 import org.junit.Test;
+
+import feign.Request;
 
 public class RequestKeyTest {
 
-    @Test
-    public void checkHashes() {
-        RequestKey request1 = new RequestKey(HttpMethod.GET, "a");
-        RequestKey request2 = new RequestKey(HttpMethod.GET, "b");
+  private RequestKey requestKey;
 
-        assertThat(request1.hashCode(), equalTo(HttpMethod.GET.hashCode() + (7 * 31)));
-        assertThat(request1.hashCode(), equalTo(request2.hashCode()));
-        assertThat(request1, not(equalTo(request2)));
-    }
+  @Before
+  public void setUp() {
+    Map<String, Collection<String>> map = new HashMap<>();
+    map.put("my-header", Arrays.asList("val"));
+    requestKey = RequestKey.builder(HttpMethod.GET, "a")
+        .headers(map)
+        .charset(StandardCharsets.UTF_16)
+        .body("content")
+        .build();
+  }
 
-    @Test
-    public void equalObject() {
-        RequestKey request1 = new RequestKey(HttpMethod.GET, "a");
-        assertThat(request1, not(equalTo(new Object())));
-    }
+  @Test
+  public void builder() throws Exception {
+    assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
+    assertThat(requestKey.getUrl(), equalTo("a"));
+    assertThat(requestKey.getHeaders().entrySet(), hasSize(1));
+    assertThat(requestKey.getHeaders().get("my-header"), equalTo((Collection<String>) Arrays.asList("val")));
+    assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
+  }
 
-    @Test
-    public void equalNull() {
-        RequestKey request1 = new RequestKey(HttpMethod.GET, "a");
-        assertThat(request1, not(equalTo(null)));
-    }
+  @Test
+  public void create() throws Exception {
+    Map<String, Collection<String>> map = new HashMap<>();
+    map.put("my-header", Arrays.asList("val"));
+    Request request = Request.create("GET", "a", map, "content".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_16);
+    requestKey = RequestKey.create(request);
 
-    @Test
-    public void equalPost() {
-        RequestKey request1 = new RequestKey(HttpMethod.GET, "a");
-        RequestKey request2 = new RequestKey(HttpMethod.POST, "a");
+    assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
+    assertThat(requestKey.getUrl(), equalTo("a"));
+    assertThat(requestKey.getHeaders().entrySet(), hasSize(1));
+    assertThat(requestKey.getHeaders().get("my-header"), equalTo((Collection<String>) Arrays.asList("val")));
+    assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
+    assertThat(requestKey.getBody(), equalTo("content".getBytes(StandardCharsets.UTF_8)));
+  }
 
-        assertThat(request1.hashCode(), not(equalTo(request2.hashCode())));
-        assertThat(request1, not(equalTo(request2)));
-    }
+  @Test
+  public void checkHashes() {
+    RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "b").build();
 
-    @Test
-    public void equalSelf() {
-        RequestKey request1 = new RequestKey(HttpMethod.GET, "a");
+    assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
+    assertThat(requestKey1, not(equalTo(requestKey2)));
+  }
 
-        assertThat(request1.hashCode(), equalTo(request1.hashCode()));
-        assertThat(request1, equalTo(request1));
-    }
+  @Test
+  public void equalObject() {
+    assertThat(requestKey, not(equalTo(new Object())));
+  }
+
+  @Test
+  public void equalNull() {
+    assertThat(requestKey, not(equalTo(null)));
+  }
+
+  @Test
+  public void equalPost() {
+    RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.POST, "a").build();
+
+    assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
+    assertThat(requestKey1, not(equalTo(requestKey2)));
+  }
+
+  @Test
+  public void equalSelf() {
+    assertThat(requestKey.hashCode(), equalTo(requestKey.hashCode()));
+    assertThat(requestKey, equalTo(requestKey));
+  }
+
+  @Test
+  public void equalMinimum() {
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
+
+    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+    assertThat(requestKey, equalTo(requestKey2));
+  }
+
+  @Test
+  public void equalExtra() {
+    Map<String, Collection<String>> map = new HashMap<>();
+    map.put("my-other-header", Arrays.asList("other value"));
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a")
+        .headers(map)
+        .charset(StandardCharsets.ISO_8859_1)
+        .build();
+
+    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+    assertThat(requestKey, equalTo(requestKey2));
+  }
+
+  @Test
+  public void equalsExtended() {
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
+
+    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+    assertThat(requestKey.equalsExtended(requestKey2), equalTo(true));
+  }
+
+  @Test
+  public void equalsExtendedExtra() {
+    Map<String, Collection<String>> map = new HashMap<>();
+    map.put("my-other-header", Arrays.asList("other value"));
+    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a")
+        .headers(map)
+        .charset(StandardCharsets.ISO_8859_1)
+        .build();
+
+    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+    assertThat(requestKey.equalsExtended(requestKey2), equalTo(false));
+  }
+
+  @Test
+  public void testToString() throws Exception {
+    assertThat(requestKey.toString(), startsWith("Request [GET a: "));
+    assertThat(requestKey.toString(), both(containsString(" with 1 ")).and(containsString(" UTF-16]")));
+  }
+
+  @Test
+  public void testToStringSimple() throws Exception {
+    requestKey = RequestKey.builder(HttpMethod.GET, "a").build();
+
+    assertThat(requestKey.toString(), startsWith("Request [GET a: "));
+    assertThat(requestKey.toString(), both(containsString(" without ")).and(containsString(" no charset")));
+  }
 
 }
+//

--- a/src/test/java/feign/mock/RequestKeyTest.java
+++ b/src/test/java/feign/mock/RequestKeyTest.java
@@ -36,132 +36,132 @@ import feign.Request;
 
 public class RequestKeyTest {
 
-  private RequestKey requestKey;
+    private RequestKey requestKey;
 
-  @Before
-  public void setUp() {
-    Map<String, Collection<String>> map = new HashMap<>();
-    map.put("my-header", Arrays.asList("val"));
-    requestKey = RequestKey.builder(HttpMethod.GET, "a")
-        .headers(map)
-        .charset(StandardCharsets.UTF_16)
-        .body("content")
-        .build();
-  }
+    @Before
+    public void setUp() {
+        Map<String, Collection<String>> map = new HashMap<>();
+        map.put("my-header", Arrays.asList("val"));
+        requestKey = RequestKey.builder(HttpMethod.GET, "a")
+                .headers(map)
+                .charset(StandardCharsets.UTF_16)
+                .body("content")
+                .build();
+    }
 
-  @Test
-  public void builder() throws Exception {
-    assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
-    assertThat(requestKey.getUrl(), equalTo("a"));
-    assertThat(requestKey.getHeaders().entrySet(), hasSize(1));
-    assertThat(requestKey.getHeaders().get("my-header"), equalTo((Collection<String>) Arrays.asList("val")));
-    assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
-  }
+    @Test
+    public void builder() throws Exception {
+        assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
+        assertThat(requestKey.getUrl(), equalTo("a"));
+        assertThat(requestKey.getHeaders().entrySet(), hasSize(1));
+        assertThat(requestKey.getHeaders().get("my-header"), equalTo((Collection<String>) Arrays.asList("val")));
+        assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
+    }
 
-  @Test
-  public void create() throws Exception {
-    Map<String, Collection<String>> map = new HashMap<>();
-    map.put("my-header", Arrays.asList("val"));
-    Request request = Request.create("GET", "a", map, "content".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_16);
-    requestKey = RequestKey.create(request);
+    @Test
+    public void create() throws Exception {
+        Map<String, Collection<String>> map = new HashMap<>();
+        map.put("my-header", Arrays.asList("val"));
+        Request request = Request.create("GET", "a", map, "content".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_16);
+        requestKey = RequestKey.create(request);
 
-    assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
-    assertThat(requestKey.getUrl(), equalTo("a"));
-    assertThat(requestKey.getHeaders().entrySet(), hasSize(1));
-    assertThat(requestKey.getHeaders().get("my-header"), equalTo((Collection<String>) Arrays.asList("val")));
-    assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
-    assertThat(requestKey.getBody(), equalTo("content".getBytes(StandardCharsets.UTF_8)));
-  }
+        assertThat(requestKey.getMethod(), equalTo(HttpMethod.GET));
+        assertThat(requestKey.getUrl(), equalTo("a"));
+        assertThat(requestKey.getHeaders().entrySet(), hasSize(1));
+        assertThat(requestKey.getHeaders().get("my-header"), equalTo((Collection<String>) Arrays.asList("val")));
+        assertThat(requestKey.getCharset(), equalTo(StandardCharsets.UTF_16));
+        assertThat(requestKey.getBody(), equalTo("content".getBytes(StandardCharsets.UTF_8)));
+    }
 
-  @Test
-  public void checkHashes() {
-    RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "b").build();
+    @Test
+    public void checkHashes() {
+        RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "b").build();
 
-    assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
-    assertThat(requestKey1, not(equalTo(requestKey2)));
-  }
+        assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
+        assertThat(requestKey1, not(equalTo(requestKey2)));
+    }
 
-  @Test
-  public void equalObject() {
-    assertThat(requestKey, not(equalTo(new Object())));
-  }
+    @Test
+    public void equalObject() {
+        assertThat(requestKey, not(equalTo(new Object())));
+    }
 
-  @Test
-  public void equalNull() {
-    assertThat(requestKey, not(equalTo(null)));
-  }
+    @Test
+    public void equalNull() {
+        assertThat(requestKey, not(equalTo(null)));
+    }
 
-  @Test
-  public void equalPost() {
-    RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.POST, "a").build();
+    @Test
+    public void equalPost() {
+        RequestKey requestKey1 = RequestKey.builder(HttpMethod.GET, "a").build();
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.POST, "a").build();
 
-    assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
-    assertThat(requestKey1, not(equalTo(requestKey2)));
-  }
+        assertThat(requestKey1.hashCode(), not(equalTo(requestKey2.hashCode())));
+        assertThat(requestKey1, not(equalTo(requestKey2)));
+    }
 
-  @Test
-  public void equalSelf() {
-    assertThat(requestKey.hashCode(), equalTo(requestKey.hashCode()));
-    assertThat(requestKey, equalTo(requestKey));
-  }
+    @Test
+    public void equalSelf() {
+        assertThat(requestKey.hashCode(), equalTo(requestKey.hashCode()));
+        assertThat(requestKey, equalTo(requestKey));
+    }
 
-  @Test
-  public void equalMinimum() {
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
+    @Test
+    public void equalMinimum() {
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
 
-    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-    assertThat(requestKey, equalTo(requestKey2));
-  }
+        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+        assertThat(requestKey, equalTo(requestKey2));
+    }
 
-  @Test
-  public void equalExtra() {
-    Map<String, Collection<String>> map = new HashMap<>();
-    map.put("my-other-header", Arrays.asList("other value"));
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a")
-        .headers(map)
-        .charset(StandardCharsets.ISO_8859_1)
-        .build();
+    @Test
+    public void equalExtra() {
+        Map<String, Collection<String>> map = new HashMap<>();
+        map.put("my-other-header", Arrays.asList("other value"));
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a")
+                .headers(map)
+                .charset(StandardCharsets.ISO_8859_1)
+                .build();
 
-    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-    assertThat(requestKey, equalTo(requestKey2));
-  }
+        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+        assertThat(requestKey, equalTo(requestKey2));
+    }
 
-  @Test
-  public void equalsExtended() {
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
+    @Test
+    public void equalsExtended() {
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a").build();
 
-    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-    assertThat(requestKey.equalsExtended(requestKey2), equalTo(true));
-  }
+        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+        assertThat(requestKey.equalsExtended(requestKey2), equalTo(true));
+    }
 
-  @Test
-  public void equalsExtendedExtra() {
-    Map<String, Collection<String>> map = new HashMap<>();
-    map.put("my-other-header", Arrays.asList("other value"));
-    RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a")
-        .headers(map)
-        .charset(StandardCharsets.ISO_8859_1)
-        .build();
+    @Test
+    public void equalsExtendedExtra() {
+        Map<String, Collection<String>> map = new HashMap<>();
+        map.put("my-other-header", Arrays.asList("other value"));
+        RequestKey requestKey2 = RequestKey.builder(HttpMethod.GET, "a")
+                .headers(map)
+                .charset(StandardCharsets.ISO_8859_1)
+                .build();
 
-    assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
-    assertThat(requestKey.equalsExtended(requestKey2), equalTo(false));
-  }
+        assertThat(requestKey.hashCode(), equalTo(requestKey2.hashCode()));
+        assertThat(requestKey.equalsExtended(requestKey2), equalTo(false));
+    }
 
-  @Test
-  public void testToString() throws Exception {
-    assertThat(requestKey.toString(), startsWith("Request [GET a: "));
-    assertThat(requestKey.toString(), both(containsString(" with 1 ")).and(containsString(" UTF-16]")));
-  }
+    @Test
+    public void testToString() throws Exception {
+        assertThat(requestKey.toString(), startsWith("Request [GET a: "));
+        assertThat(requestKey.toString(), both(containsString(" with 1 ")).and(containsString(" UTF-16]")));
+    }
 
-  @Test
-  public void testToStringSimple() throws Exception {
-    requestKey = RequestKey.builder(HttpMethod.GET, "a").build();
+    @Test
+    public void testToStringSimple() throws Exception {
+        requestKey = RequestKey.builder(HttpMethod.GET, "a").build();
 
-    assertThat(requestKey.toString(), startsWith("Request [GET a: "));
-    assertThat(requestKey.toString(), both(containsString(" without ")).and(containsString(" no charset")));
-  }
+        assertThat(requestKey.toString(), startsWith("Request [GET a: "));
+        assertThat(requestKey.toString(), both(containsString(" without ")).and(containsString(" no charset")));
+    }
 
 }
 //


### PR DESCRIPTION
Bug fixes:
* RequestKey.hash() must return equal values when equal() returns true

Improvements:
* RequestKey:
  * use Java's hash()
  * extended checks to cover headers, charset and body
  * added builder pattern

* MockClient:
  * use Java's HTTP status codes
  * support sequential executions
  * added more add(), ok() and notOk() methods
  * added verifyStatus(), which currently doesn't check anything for non-sequential tests
  * minor streamlining

* updated readme

---

* As I lined out above verifyStatus() currently has no code to check anything for non-sequential tests. As I only use it the sequential way I can't tell what makes sense to test here.
* In case this pull request makes it into the library, it may make sense to set the new version to 1.0 and have the sequential field in MockClient default to true.